### PR TITLE
Only email errors on change of status.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ notifications:
     recipients:
       - mpinheir@gmail.comm
       - paganini+travis@paganini.net
-    on_success: always # default: change
-    on_failure: always # default: always
+    on_success: change
+    on_failure: always
 
 language: go
 


### PR DESCRIPTION
- This should reduce the "mail-on-green" spam.