### PR TITLE
Conserto de numeração, instruções p/upstream.

### DIFF
--- a/content/desafios/d01.md
+++ b/content/desafios/d01.md
@@ -1,6 +1,6 @@
 +++
 title = "Desafio #1"
-date = "2017-04-08T17:00:00-07:00"
+date = "2018-09-27T20:00:00-07:00"
 tags = ["programação"]
 categories = ["desafios"]
 banner = "img/banners/octocat.png"
@@ -10,31 +10,22 @@ type = "blog"
 **Adicione o seu nome a lista de participantes do grupo OsProgramadores no GitHub.**
 
 1. Leia o tutorial sobre [Git](https://tableless.com.br/tudo-que-voce-queria-saber-sobre-git-e-github-mas-tinha-vergonha-de-perguntar/).
+1. Crie sua conta no [GitHub](https://github.com).
+1. Acesse o [projeto do site do grupo](https://github.com/OsProgramadores/op-website-hugo) OsProgramadores e faça o fork do projeto para a sua conta no GitHub.
+1. [Instale o git](https://git-scm.com/downloads) na sua máquina.
+1. Acesse a linha de comando (Windows) ou abra um terminal (Linux ou OSX).
+1. Crie um diretório onde você deseja instalar o projeto do site.
+1. Crie um clone **do seu repositório** no github na sua máquina:
 
-2. Crie sua conta no [GitHub](https://github.com).
-
-3. Acesse o [projeto do site do grupo](https://github.com/OsProgramadores/op-website-hugo) OsProgramadores e faça o fork do projeto para a sua conta no GitHub.
-
-4. [Instale o git](https://git-scm.com/downloads) na sua máquina.
-
-5. Acesse a linha de comando (Windows) ou abra um terminal (Linux ou OSX).
-
-6. Crie um diretório onde você deseja instalar o projeto do site.
-
-7. Crie um clone **do seu repositório** no github na sua máquina:
-
-```
-    git clone --recursive https://github.com/<seu usuário do GitHub>/op-website-hugo.git
-```
-
-8. Crie um _branch_ de trabalho com o command `git checkout -b inclusao-de-participante`
-
-9. Adicione os seus dados ao arquivo PARTICIPANTES.md e grave o arquivo.
-  
-    1. É importante que esse arquivo esteja em ordem alfabética
-
-10. Confirme suas modificações com o `git commit -a`.
-
-10. Envie suas modificações de volta pro github usando o comando `git push origin`.
-
-11. Acesse o fork do repositório op-website-hugo na sua conta do GitHub e solicite um _Pull Request_ para o repositório do [OsProgramadores](https://github.com/OsProgramadores/op-website-hugo)
+   ```
+   git clone --recursive https://github.com/<seu usuário do GitHub>/op-website-hugo.git
+   ```
+1. Crie um remote apontando pro repositório original. Esse passo não é completamente necessário na maioria dos casos mas será necessário em caso de conflitos de versões:
+   ```
+   git remote add upstream https://github.com/osprogramadores/op-website-hugo.git
+   ```
+1. Crie um _branch_ de trabalho com o command `git checkout -b inclusao-de-participante`
+1. Adicione os seus dados ao arquivo PARTICIPANTES.md e grave o arquivo. **É importante que esse arquivo esteja em ordem alfabética por nome!**
+1. Confirme suas modificações com o `git commit -a`.
+1. Envie suas modificações de volta pro github usando o comando `git push origin`.
+1. Acesse o fork do repositório op-website-hugo na sua conta do GitHub e solicite um _Pull Request_ para o repositório do [OsProgramadores](https://github.com/OsProgramadores/op-website-hugo)


### PR DESCRIPTION
- Não é necessário (ou desejável) ter os números reais. Colocando todos como "1." dá ao markdown a chance de numerar em ordem crescente.
- Adicionado um indent ao bloco "preformatado", pra evitar a quebra da numeração.
- Adicionadas instruções de como adicionar um remote apontando para o upstream.