### PR TITLE
 Adiciona links do Telegram à links.md 

### DIFF
--- a/content/blog/grupos_telegram.md
+++ b/content/blog/grupos_telegram.md
@@ -17,11 +17,8 @@ Grupo sobre Assembly.
 [Android Dev Drops](https://t.me/android_drops)  
 Grupo sobre desenvolvimento nativo para Android.
 
-[Angular Brasil](https://t.me/angularJSBrasil)  
-Grupo sobre AngularJS.
-
-[BotCaverna](https://t.me/joinchat/AAAAAENNXyU9OWfSTzD8DQ)  
-Grupo sobre desenvolvimento de bots.
+[Angular Brasil](https://t.me/AngularBrasil)  
+Grupo sobre Angular.
 
 [C is LOVE](https://t.me/c_user)  
 Grupo destinado a assuntos relacionados a Linguagem "C".
@@ -40,9 +37,6 @@ Grupo brasileiro de programadores e entusiastas da linguagem de programação Da
 
 [DBA BRASIL](https://t.me/DbaBrasil)  
 Grupo sobre DBA.
-
-[Delphi](https://t.me/joinchat/DtwgRkCKYHU30rzuoJpPrg)  
-Grupo direcionado aos programadores Delphi.
 
 [DevCodeBr - Android/Java/Kotlin](https://t.me/devcodebr_android)  
 Grupo sobre desenvolvimento Android/Java/Kotlin.
@@ -106,12 +100,6 @@ Grupo sobre PHP.
 
 [Polymer Brasil](https://t.me/polymerbr)  
 Grupo para interessados e profissionais que trabalham com [Polymer](https://www.polymer-project.org/).
-
-[Programação Funcional Brasil](https://t.me/programacaofuncionalbrasil)  
-Grupo voltado à programação funcional em geral
-
-[Programeiros](https://t.me/joinchat/CxaN0D-xLVriZgVzWBM2Fw)  
-Grupo destinado a desenvolvedores iniciantes ou experientes, com foco em projetos.
 
 [PyCoding](https://t.me/pyCoding)  
 Maior grupo sobre Python no Telegram (em inglês).

--- a/content/links.md
+++ b/content/links.md
@@ -20,11 +20,11 @@ tags = ["links"]
     </tr>
     <tr>
       <td><a href="https://www.cursoemvideo.com/">Cursos em Video</a></td>
-      <td>Cursos de Front e Back-end, Marketing Digital, Banco de Dados</td>
+      <td>Cursos de Front-End e Back-End, Marketing Digital, Banco de Dados</td>
     </tr>
     <tr>
       <td><a href="https://www.codecademy.com">Code Academy</a></td>
-      <td>Cursos gratuitos de Desenvolvimento web, Programação e Data Science</td>
+      <td>Cursos gratuitos de Desenvolvimento Web, Programação e Data Science</td>
     </tr>
     <tr>
       <td><a href="https://docs.microsoft.com/en-us/dotnet/csharp/tutorials/">C# Tutorials</a></td>
@@ -32,7 +32,7 @@ tags = ["links"]
     </tr>
     <tr>
       <td><a href="https://www.freecodecamp.org/">FreeCodeCamp</a></td>
-      <td>Curso gratuito de Front e Back-end mais completo que você vai encontrar, com atividades e projetos, ao final receba um certificado</td>
+      <td>Curso gratuito de Front-End e Back-End mais completo que você vai encontrar, com atividades e projetos, ao final receba um certificado</td>
     </tr>
     <tr>
       <td><a href="http://jstherightway.org/pt-br/">JavaScript The Right Way</a></td>
@@ -52,7 +52,7 @@ tags = ["links"]
     </tr>
     <tr>
       <td><a href="https://www.rust-lang.org/learn">Rust</a></td>
-      <td>Curso, em inglês sobre a linguagem de programação Rust</td>
+      <td>Curso sobre a linguagem de programação Rust (em inglês)</td>
     </tr>
     <tr>
       <td><a href="https://www.sololearn.com/">SoloLearn</a></td>
@@ -62,7 +62,6 @@ tags = ["links"]
       <td><a href="https://go-tour-br.appspot.com/welcome/1">Um tour por Go</a></td>
       <td>Um tour pela linguagem de Programação Go</td>
     </tr>
-    
   </tbody>
 </table>
 
@@ -75,6 +74,7 @@ tags = ["links"]
     </tr>
   </thead>
   <tbody>
+    </tr>
     <tr>
       <td><a href="https://caniuse.com/">Can I Use</a></td>
       <td>Site para verificar a compatibilidade e funcionalidade de recursos web, tais como elementos do HTML e propriedades CSS</td>
@@ -85,15 +85,15 @@ tags = ["links"]
     </tr>
     <tr>
       <td><a href="https://www.gimp.org/">GIMP</a></td>
-      <td>Editor de imagens grátis e open source</td>
+      <td>Editor de imagens grátis e Open Source</td>
     </tr>
     <tr>
       <td><a href="https://github.com/">GitHub</a></td>
-      <td>Se vai ser programador, essa ferramenta é essencial para hospedar seus códigos. Muitas empresas costumam pedir seu Github para analisar seus códigos. Temos um <a href='/desafios/d01/'>desafio</a> no site com tutorial ensinando a utilizá-lo</td>
+      <td>Se vai ser programador, essa ferramenta é essencial para hospedar seus códigos. Muitas empresas costumam pedir seu GitHub para analisar seus códigos. Temos um <a href='/desafios/d01/'>desafio</a> no site com tutorial ensinando a utilizá-lo</td>
     </tr>
     <tr>
-      <td><a href="https://education.github.com/pack">Github educacional</a></td>
-      <td>Assinatura de ferramentas, créditos em sites de armazenamento e hosting, repositórios privados grátis e muito mais no pack do github para estudantes</td>
+      <td><a href="https://education.github.com/pack">GitHub Education</a></td>
+      <td>Assinatura de ferramentas, créditos em sites de armazenamento e hosting, repositórios privados grátis e muito mais no pack do GitHub para estudantes</td>
     </tr>
     <tr>
       <td><a href="http://www.guj.com.br/">Guj</a></td>
@@ -101,7 +101,7 @@ tags = ["links"]
     </tr>
     <tr>
       <td><a href="https://learngitbranching.js.org/">Learn Git Branching</a></td>
-      <td>Aprendendo intuitivamente como funcionam os comandos de branching, como 'checkout', 'merge' e 'rebase'</td>
+      <td>Aprendendo intuitivamente como funcionam os comandos de branching, como <code>checkout</code>, <code>merge</code> e <code>rebase</code></td>
     </tr>
     <tr>
       <td><a href="https://repl.it">Repl.it</a></td>
@@ -109,7 +109,7 @@ tags = ["links"]
     </tr>
     <tr>
       <td><a href="https://regex101.com/">Regex101</a></td>
-      <td>Ferramenta para testar suas expressões regulares em Php, Python, Javascript e Go</td>
+      <td>Ferramenta para testar suas expressões regulares em Php, Python, JavaScript e Go</td>
     </tr>
     <tr>
       <td><a href="http://www.regexpal.com/">Regex Pal</a></td>
@@ -117,15 +117,15 @@ tags = ["links"]
     </tr>
     <tr>
       <td><a href="http://rextester.com/l/pascal_online_compiler">RexTester</a></td>
-      <td>Compilador online de Java, C, C#, C++, Javascript, Lua, Php, Python, Ruby, Scala entre outros</td>
+      <td>Compilador online de Java, C, C#, C++, JavaScript, Lua, Php, Python, Ruby, Scala, entre outros</td>
     </tr>
     <tr>
       <td><a href="https://pt.stackoverflow.com/">StackOverFlow</a></td>
-      <td>Melhor fórum do mundo para programadores; use com moderação</td>
+      <td>Melhor fórum do mundo para programadores. Use com moderação</td>
     </tr>
     <tr>
       <td><a href="https://tinypng.com/">TinyPng</a></td>
-      <td>Compacte imagens de <strong>PNG</strong> sem perder qualidade. Excelente para deixar seu site mais leve</td>
+      <td>Compacte imagens de PNG sem perder qualidade. Excelente para deixar seu site mais leve</td>
     </tr>
     <tr>
       <td><a href="http://jigsaw.w3.org/css-validator/">W3 CSS Validator</a></td>
@@ -147,13 +147,14 @@ tags = ["links"]
     </tr>
   </thead>
   <tbody>
+    </tr>
     <tr>
       <td><a href="http://devdocs.io/">DevDocs</a></td>
       <td>DevDocs é um site que disponibiliza a documentação de centenas de linguagens</td>
     </tr>
     <tr>
       <td><a href="https://www.w3schools.com/default.asp">HTML, CSS, Javascript</a></td>
-      <td>Documentação front-end e back-end com muitos tutoriais</td>
+      <td>Documentação Front-End e Back-End com muitos tutoriais</td>
     </tr>
     <tr>
       <td><a href="https://kotlinlang.org/">Kotlin</a></td>
@@ -169,7 +170,7 @@ tags = ["links"]
     </tr>
     <tr>
       <td><a href="https://wiki.python.org.br/DocumentacaoPython">Python</a></td>
-      <td>Site com link para documentação do Python, além de vários artigos e dicas de como e por onde começar com Python</td>
+      <td>Site com links para documentação do Python, além de vários artigos e dicas de como e por onde começar com Python</td>
     </tr>
   </tbody>
 </table>
@@ -183,17 +184,18 @@ tags = ["links"]
     </tr>
   </thead>
   <tbody>
+    </tr>
     <tr>
       <td><a href="https://www.caelum.com.br/apostila-java-orientacao-objetos/">Java OO</a></td>
-      <td>Apostila online de Java Orientado a Objetos. Também pode ser baixada no site gratuitamente</td>
+      <td>Apostila online de Java Orientado a Objetos, distribuída pela Caelum gratuitamente</td>
     </tr>
     <tr>
       <td><a href="https://www.caelum.com.br/apostila-html-css-javascript/">Front-End</a></td>
-      <td>Apostila de HTML, CSS e Javascript, distribuída pela Caelum de forma gratuita</td>
+      <td>Apostila de HTML, CSS e JavaScript, distribuída pela Caelum gratuitamente</td>
     </tr>
     <tr>
       <td><a href="https://www.caelum.com.br/apostila-ux-usabilidade-mobile-web/">UX e Usabilidade</a></td>
-      <td>Apostila de Usabilidade mobile e Web e User Experience</td>
+      <td>Apostila de Usabilidade Mobile e Web e User Experience, distribuída pela Caelum gratuitamente</td>
     </tr>
     <tr>
       <td><a href="http://piazinho.com.br/download/expressoes-regulares-3-tabelas.pdf">Expressões Regulares</a></td>
@@ -211,6 +213,10 @@ tags = ["links"]
       <td><a href="https://www.syncfusion.com/ebooks/">Syncfusion Ebooks</a></td>
       <td>Dezenas de ebooks sobre várias tecnologias, com a proposta de serem sucintos, como já diz no título. Há diversos, por exemplo: Bootstrap, .NET, Java, HTTP. (necessário cadastro para alguns)</td>
     </tr>
+    <tr>
+      <td><a href="https://books.goalkicker.com/">Syncfusion Ebooks</a></td>
+      <td>Mais de 40 livros de vários assuntos relacionados à programação, criados e reunidos pelos melhores do Stack Overflow</td>
+    </tr>    
   </tbody>
 </table>
 
@@ -225,7 +231,7 @@ tags = ["links"]
   <tbody>
     <tr>
       <td><a href="http://labs.bluesoft.com.br/category/podcast/">BlueSoft</a></td>
-      <td>Podcast sobre desenvolvimento ágil, software e tecnologia, apresentado por André Faria, Luiz Farias Jr, e toda a equipe da Bluesoft</td>
+      <td>Podcast sobre desenvolvimento ágil, software e tecnologia, apresentado por André Faria, Luiz Farias Jr. e toda a equipe da Bluesoft</td>
     </tr>
     <tr>
       <td><a href="http://castalio.info/">Castalio</a></td>
@@ -243,7 +249,8 @@ tags = ["links"]
       <td><a href="https://www.lambda3.com.br/lambda3-podcast/">Lambda3</a></td>
       <td>Podcast sobre assuntos técnicos e não técnicos criado pela empresa Lambda3</td>
     </tr>
-     <tr>
+     </tr>
+    <tr>
       <td><a href="https://jovemnerd.com.br/playlist/nerdtech/">Nerd Tech</a></td>
       <td>Podcast fruto da parceria entre o Nerdcast e o pessoal da Alura</td>
     </tr>
@@ -253,7 +260,7 @@ tags = ["links"]
     </tr>
     <tr>
       <td><a href="https://mundopodcast.com.br/podprogramar/">PodProgramar</a></td>
-      <td>Podcast apresentado por desenvolvedoras focado em programação, notícias e histórias, tudo com o toque feminino numa área dominada por homens.</td>
+      <td>Podcast apresentado por desenvolvedoras focado em programação, notícias e histórias. Tudo com o toque feminino numa área dominada por homens</td>
     </tr>
     <tr>
       <td><a href="https://pizzadedados.com/">PIZZA DE DADOS</a></td>
@@ -262,6 +269,194 @@ tags = ["links"]
     <tr>
       <td><a href="https://quebradev.com.br/">QUEBRADEV</a></td>
       <td>Um podcast de origem periférica e com destino voltado à origem</td>
+    </tr>
+  </tbody>
+</table>
+
+## Grupos sobre programação no Telegram
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col">Item</th>
+      <th scope="col">Descrição</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://t.me//arquiteturadotnet">Arquitetura de Software | .NET</a></td>
+      <td>Grupo sobre Arquitetura de Software | .NET</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//assemblybr">Assembly Brasil</a></td> 
+      <td>Grupo sobre Assembly</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//android_drops">Android Dev Drops</a></td>
+      <td>Grupo sobre desenvolvimento nativo para Android</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//AngularBrasil">Angular Brasil</a></td> 
+      <td>Grupo sobre Angular</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//c_user">C is LOVE</a></td>
+      <td>Grupo destinado a assuntos relacionados a Linguagem "C"</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//ccppbrasil">C/C++ Brasil</a></td>
+      <td>Grupo sobre C, C++ e outros assuntos</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//devcordova">Cordova developers</a></td>
+      <td>Grupo sobre desenvolvimento Cordova</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//cssbr">CSS Brasil</a></td>
+      <td>Grupo técnico sobre Cascading Style Sheets</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//dartbrasil">Dart Brasil</a></td>
+      <td>Grupo brasileiro de programadores e entusiastas da linguagem de programação Dart e do Framework Mobile Flutter</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//DbaBrasil">DBA BRASIL</a></td> 
+      <td>Grupo sobre DBA</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//devcodebr_android">DevCodeBr - Android/Java/Kotlin</a></td> 
+      <td>Grupo sobre desenvolvimento Android/Java/Kotlin</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//djangobrasil">Django Brasil</a></td>
+      <td>Grupo sobre Django (Python)</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//dotnetbr">DotNet Brasil</a></td>
+      <td>Grupo de discussões sobre .NET, ASP.NET, Mono, .NET Core, Xamarin, etc</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//electronJs_BR">ElectronJS Brasil</a></td>
+      <td>Grupo sobre Electron</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//elmbrasil">Elm Brasil</a></td>
+      <td>Grupo sobre Elm</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//etherbr">EthereumBR</a></td>
+      <td>Grupo sobre Ethereum, Solidity, e tecnologias relacionadas</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//flutterbr">Flutter Brasil</a></td> 
+      <td>Grupo sobre desenvolvimento mobile com Flutter</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//frontendbrasil">Frontend Brasil</a></td>
+      <td>Grupo sobre programação front end</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//GitBrasil">Git Brasil</a></td>
+      <td>Grupo brasileiro sobre Git</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//gopheliacoding">GopheLia</a></td>
+      <td>Grupo sobre Go, Perl, Julia e todas as "pequenas grandes langs"</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//htmlbr">HTML Brasil</a></td>
+      <td>Grupo técnico sobre Hyper Text Markup Language</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//ionicbrasil)[Ionic Brasil</a></td> 
+      <td>Grupo sobre programação Ionic</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//iosdrops">iOS Dev Drops</a></td>
+      <td>Grupo sobre desenvolvimento nativo para iOS</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//javascriptbrasil">JavaScript Brasil</a></td>
+      <td>Grupo sobre JavaScript</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//lualanguagebrasil">Lua Programming Language Brasil</a></td>
+      <td>Grupo sobre a Linguagem Lua
+    </tr>
+    <tr>
+      <td><a href="https://t.me//NodejsBR">Node.js Brasil</a></td> 
+      <td>Grupo sobre Node.js</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//osprogramadores">Os Programadores</a></td> 
+      <td>Grupo que tem como objetivo incentivar o aprendizado de programação. É aberto à conversas sobre programação em geral, de todos os níveis</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//PodProgramar">Ouvintes do PodProgramar</a></td>
+      <td>Grupo de Ouvintes do Podcast PodProgramar</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//perlbrasil">Perl Brasil</a></td>
+      <td>Grupo sobre Perl e outros assuntos</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//phpbrasil">PHP Brasil</a></td>
+      <td>Grupo sobre PHP</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//polymerbr">Polymer Brasil</a></td>
+      <td>Grupo para interessados e profissionais que trabalham com Polymer</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//pyCoding">PyCoding</a></td>
+      <td>Grupo sobre Python no Telegram (em inglês)</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//pykivy">PyKivy - pt_BR</a></td>
+      <td>Grupo destinado ao desenvolvimento de apps com o framework Kivy (Python)</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//pythonbr">PythonBr</a></td>
+      <td>Grupo Brasileiro sobre desenvolvimento em Python</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//PythonRio">PythonRio</a></td>
+      <td>Grupo da comunidade Python do Rio de Janeiro</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//qtbrasil">Qt Brasil</a></td>
+      <td>Grupo sobre Qt</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//reactnativedrops">React Native Drops</a></td>
+      <td>Grupo sobre desenvolvimento mobile com React Native</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//rubybrasil">Ruby Brasil</a></td>
+      <td>Grupo sobre a linguagem Ruby</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//stenciljsbrasil">StencilJS Brasil</a></td>
+      <td>Grupo sobre StencilJS</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//theprogrammingartgroup">The Art of Programming</a></td>
+      <td>Grupo sobre programação em geral (em inglês)</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//tinocanada">TI no Canadá</a></td>
+      <td>Grupo sobre como trabalhar com TI no Canadá</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//Vala_BR">Vala - Linguagem de Programação</a></td>
+      <td>Grupo sobre a Linguagem de Programação Vala</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//vimbr">VIM-BR</a></td>
+      <td>Grupo sobre VIM</td>
+    </tr>
+    <tr>
+      <td><a href="https://t.me//web2pybrasil">Web2py</a></td>
+      <td>Grupo sobre Framework Web2py (Python)</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Adiciona os links do Telegram da postagem do blog à página Links. Também padroniza a ortografia de alguns termos por todo o documento.