### PR TITLE
Spellcheck

### DIFF
--- a/content/regras.md
+++ b/content/regras.md
@@ -8,7 +8,7 @@ markup = "markdown"
 
 [OsProgramadores](http://osprogramadores.com) é uma entidade formada por um grupo de profissionais experientes na área de computação com o objetivo de promover a discussão de temas relacionados ao desenvolvimento de software (algoritmos, ferramentas, linguagens, etc).
 
-A maior parte das discussões acontece no nosso grupo no Telegram ([#OsProgramadores](https://t.me/OsProgramadores)). O objetivo do grupo é oferecer um local informal e descontraído para a troca de informações, dúvidas, e conversas em geral sobre computadores e tópicos relacionados.
+A maior parte das discussões acontece no nosso grupo no Telegram ([@OsProgramadores](https://t.me/OsProgramadores)). O objetivo do grupo é oferecer um local informal e descontraído para a troca de informações, dúvidas e conversas em geral sobre computadores e tópicos relacionados.
 
 Este documento contém um conjunto de regras básicas para o uso do grupo. Os administradores **fortemente recomendam a leitura deste documento para todos os participantes do grupo**.
 
@@ -38,15 +38,15 @@ Comportamentos não recomendados:
 
 ### Mantenha a sua pergunta dentro do tópico do grupo
 
-O grupo foi feito para ajudar a todos com problemas relacionados a programação, assim como discutir linguagens, algoritmos, etc. Mantenha a sua pergunta dentro do tópico do grupo, sempre que possível.
+O grupo foi feito para ajudar a todos com problemas relacionados à programação, assim como discutir linguagens, algoritmos, etc. Mantenha a sua pergunta dentro do tópico do grupo, sempre que possível.
 
 ### O grupo não vai fazer o seu dever de casa
 
-Perguntas como "Meu trabalho da faculdade é fazer X" são bem vindas, **desde que o trabalho já tenha sido iniciado**. Em outras palavras, é OK perguntar porque um programa ou pedaço de código não funciona, mas não é OK perguntar como fazer sem ter tentado _nada_ antes.
+Perguntas como "Meu trabalho da faculdade é fazer X" são bem vindas, **desde que o trabalho já tenha sido iniciado**. Em outras palavras, é OK perguntar por que um programa ou pedaço de código não funciona, mas não é OK perguntar como fazer sem ter tentado _nada_ antes.
 
 ### Demonstre interesse
 
-É difícil ajudar aqueles que não tem qualquer interesse em resolver os próprios problemas. Infelizmente, várias pessoas esperam que uma solução apareça, sem fazer qualquer tipo de esforço, __mesmo quando alguém recomenda um caminho a ser tomado__. Lembre-se, o grupo está aqui pra ajudar, não pra resolver os seus problemas.
+É difícil ajudar aqueles que não têm qualquer interesse em resolver os próprios problemas. Infelizmente, várias pessoas esperam que uma solução apareça, sem fazer qualquer tipo de esforço, __mesmo quando alguém recomenda um caminho a ser tomado__. Lembre-se, o grupo está aqui pra ajudar, não pra resolver os seus problemas.
 
 ### Faça-se disponível para aqueles tentando ajudar
 
@@ -58,9 +58,9 @@ Todos os membros do grupo são voluntários. Se a sua pergunta não despertou in
 
 ### Não envie screenshots ou pastes do seu código
 
-Screenshots mostrando o seu código não são a melhor forma de obter ajuda. Coloque o código (ou pedaço de código) no http://repl.it e então coloque o link para o grupo, com uma descrição sumária do problema. Screenshots de *sintomas* são aceitáveis (por exemplo, mostrando um problema de formatação criado pelo seu programa).
+Screenshots mostrando o seu código não são a melhor forma de obter ajuda. Coloque o código (ou pedaço de código) no [Repl.it](https://repl.it/languages) e então coloque o link para o grupo, com uma descrição sumária do problema. Screenshots de *sintomas* são aceitáveis (por exemplo, mostrando um problema de formatação criado pelo seu programa).
 
-Se a sua linguagem não é uma linguagem aceita pelo repl.it, recomendamos o http://termbin.com ou um gist no github (http://gist.github.com).
+Se a sua linguagem não é uma linguagem aceita pelo [Repl.it](https://repl.it/languages), recomendamos o [termbin.com](http://termbin.com) ou um [gist no Github](http://gist.github.com).
 
 ### Não envie pedidos via áudio
 
@@ -72,4 +72,4 @@ Salvo casos especiais, discuta as suas dúvidas em público, no grupo. Isso perm
 
 ## Ainda tem dúvidas?
 
-Sinta-se a vontade para contactar um dos administradores listados na nossa home page, [osprogramadores.com](http://osprogramadores.com).
+Sinta-se à vontade para contatar um dos administradores listados na nossa home page, [osprogramadores.com](http://osprogramadores.com).


### PR DESCRIPTION
- No Telegram canais, grupos e usuários são identificados pelo @, não pelo #. Vírgula indevida.
- Crase.
- Porquês.
- Verbo ter concorda com o sujeito (aqueles/eles).
- A página inicial do Repl.it não é mais tão intuitiva para escolher uma linguagem se você não tiver uma conta, enviando o usuário direto para http://repl.it/languages o deixa numa posição mais fácil de acessar a função de IDE online. Embelezar alguns links.
- Crase. Português brasileiro.