### PR TITLE
Adiciona link global do grupo Telegram

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,6 +47,11 @@ paginate = 12
     url = "/scores/"
     weight = 7
 
+[[menu.main]]
+    name = "Ir ao Telegram"
+    url = "/scores/"
+    weight = 7
+
 [params]
     viewMorePostLink = "/blog/"
     author = "mpinheir"

--- a/static/css/style.default.css
+++ b/static/css/style.default.css
@@ -308,7 +308,7 @@ ul.list-style-none {
   text-transform: uppercase;
   text-decoration: underline;
   font-weight: bold;
-  letter-spacing: 0.08em;
+/*  letter-spacing: 0.08em; */
   border-top: solid 5px transparent;
 }
 .navbar ul.nav > li > a:hover {


### PR DESCRIPTION
Adicionei o item "Ir ao Telegram" no menu global e comentei o letter spacing no CSS para que o menu não "transbordasse" pra debaixo do logotipo, fazendo com que o header ficasse alto e desproporcional.