### PR TITLE
Fix broken "recently articles" under hugo 0.58+

### DIFF
--- a/layouts/partials/recent_posts.html
+++ b/layouts/partials/recent_posts.html
@@ -1,0 +1,69 @@
+{{ if isset .Site.Params "recent_posts" }}
+{{ if .Site.Params.recent_posts.enable }}
+<section class="bar background-white no-mb">
+    <div class="container">
+
+        <div class="col-md-12">
+            <div class="heading text-center">
+                <h2>{{ .Site.Params.recent_posts.title }}</h2>
+            </div>
+
+            <p class="lead">
+              {{ .Site.Params.recent_posts.subtitle | markdownify }}
+            </p>
+
+            <!-- *** BLOG HOMEPAGE *** -->
+
+            <div class="row">
+
+                {{ $posts := .Paginate (where .Site.RegularPages "Type" "blog") }}
+                {{ range first 4 $posts.Pages }}
+                <div class="col-md-3 col-sm-6">
+                    <div class="box-image-text blog">
+                        <div class="top">
+                            <div class="image" style="overflow:hidden">
+                                {{ if isset .Params "banner" }}
+                                <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="" >
+                                {{ else }}
+                                <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
+                                {{ end }}
+                            </div>
+                            <div class="bg"></div>
+                            <div class="text">
+                                <p class="buttons">
+                                    <a href="{{ .Permalink }}" class="btn btn-template-transparent-primary"><i class="fa fa-link"></i> {{ i18n "readMore" }}</a>
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="content">
+                            <h4><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
+                            <p class="author-category">
+                            {{ with .Params.author }}
+                            {{ i18n "authorBy" }} <a href="#">{{ . }}</a>
+                            {{ end }}
+                            {{ i18n "publishedOn" }} {{ .Date.Format .Site.Params.date_format }}
+                            </p>
+                            <p class="intro">{{ .Summary }}</p>
+                            <p class="read-more">
+                              <a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
+                            </p>
+                        </div>
+                    </div>
+                    <!-- /.box-image-text -->
+
+                </div>
+                {{ end }}
+
+            </div>
+            <!-- /.row -->
+
+            <!-- *** BLOG HOMEPAGE END *** -->
+
+        </div>
+    </div>
+    <!-- /.container -->
+</section>
+<!-- /.bar -->
+{{ end }}
+{{ end }}


### PR DESCRIPTION
This file was copied from the theme, with .Data.Pages changed to
.Site.RegularPages, which is a list of all regular pages on the entire
site (hugo 0.58+). For further details, see:
https://gohugo.io/variables/site/#site-variables-list