### PR TITLE
Desafio 12 corrigido para exemplo corresponder à saída

### DIFF
--- a/content/desafios/d12.md
+++ b/content/desafios/d12.md
@@ -46,6 +46,7 @@ Considere a lista de números:
 137
 65535
 63336
+17179869184
 ```
 
 A saída deverá ser:


### PR DESCRIPTION
Encontrei uma diferença entre o exemplo de entrada e a saída no texto do Desafio 12, optei por resolver acrescentando uma linha na entrada com o valor 17179869184. Apagar a última linha da saída também resolveria o problema, mas optei por acrescentar o valor na entrada.