### PR TITLE
Remove grupo JavaScript Brasil.

### DIFF
--- a/data/links/telegram-grupos.yaml
+++ b/data/links/telegram-grupos.yaml
@@ -378,12 +378,8 @@ sources:
   title: "Java (Português)"
   description: "Grupo Português sobre Java"
 
-- url: "https://t.me//javascriptbrasil"
-  title: "JavaScript Brasil"
-  description: "Grupo sobre JavaScript"
-
 - url: "https://t.me/javascriptbr"
-  title: "JavaScript Brasil 2"
+  title: "JavaScript Brasil"
   description: "Grupo técnico brasileiro sobre JavaScript"
 
 - url: "https://t.me/joomlabrasil"


### PR DESCRIPTION
- Remove o grupo JavaScript Brasil, que foi aparentemente abandonado.
- Renomeia o "Javascript Brasil 2" --> Javascript Brasil.
- Fixes #700
