### PR TITLE
Push website every 30m, use checksums for rsync.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,6 +48,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: '7 * * * *'
+    - cron: '37 * * * *'
 
 jobs:
   deploy_op_website:
@@ -95,7 +98,7 @@ jobs:
       - name: Deploy using rsync
         uses: burnett01/rsync-deployments@4.0
         with:
-          switches: -avpzr --delete
+          switches: -avpzcr --delete
           path: website/public/
           remote_host: jupiter.osprogramadores.com
           remote_port: 2345


### PR DESCRIPTION
- Rebuild and push the website every 30m, in addition to doing it on
  pushes. This guarantees that changes to op-desafios will be picked
  eventually.
- Change rsync to use checksums, so that only files that effectively
  changed will be copied.
