### PR TITLE
Sugestão de frase para remover ambiguidade no texto do desafio 03

### DIFF
--- a/content/desafios/d03.md
+++ b/content/desafios/d03.md
@@ -22,7 +22,7 @@ Neste desafio, a idéia é imprimir todos os *números* palindrômicos entre doi
 outros números. Tal como as palavras, os números palindrômicos mantém o mesmo
 valor se lidos de trás para a frente.
 
-Observe que o número inicial e final devem ser incluídos nos resultados.
+Observe que o número inicial e final devem ser incluídos nos resultados, caso também sejam palíndromos.
 
 Exemplo 1:
 Dado o número inicial 1 e número final 20, o resultado seria: 1, 2, 3, 4, 5, 6,


### PR DESCRIPTION
# Contexto

Ao ler o texto do desafio 03 para fazê-lo, percebi uma aparente ambiguidade na frase abaixo:

> Observe que o número inicial e final devem ser incluídos nos resultados.

> Exemplo 1:
> Dado o número inicial 1 e número final 20, o resultado seria: 1, 2, 3, 4, 5, 6,
7, 8, 9, 11.

> Exemplo 2:
Dado o numero inicial 3000 e número final 3010, o resultado seria: 3003.

> Exemplo 3:
Dado o número inicial 101 e número final 121, o resultado seria: 101, 111, 121.

O exemplo 3 ajuda a remover a ambiguidade mas sem uma condição extra, sugerida nesse PR, o parágrafo inicial aparenta indicar que o número inicial e final devem sempre ser inseridos nos resultados, sendo palíndromos ou não.

Minha sugestão é alterar para (porção em negrito):

> Observe que o número inicial e final devem ser incluídos nos resultados **, caso também sejam palíndromos.**