### PR TITLE
Algumas sugestões para as instruções dos desafios

### DIFF
--- a/layouts/_default/desafios.html
+++ b/layouts/_default/desafios.html
@@ -15,7 +15,7 @@
             <div class="row">
               <div class="alert alert-warning" role="alert">
                 <h1>Informações Importantes</h1>
-                Antes de enviar a sua contribuição:
+                Antes de enviar a sua solução para um dos desafios:
                 <ul>
                   <li>
                     Leia atentamente as instruções para contribuições

--- a/layouts/_default/desafios.html
+++ b/layouts/_default/desafios.html
@@ -18,8 +18,8 @@
                 Antes de enviar a sua contribuição:
                 <ul>
                   <li>
-                    Leia atentamente as <a href="https://github.com/osprogramadores/op-desafios/#readme">instruções para contribuições</a>
-                    no <a href="https://github.com/osprogramadores/op-desafios">repositório op-desafios</a>.
+                    Leia atentamente as instruções para contribuições
+                    no <a href="https://github.com/osprogramadores/op-desafios/#readme">repositório op-desafios</a>.
                   </li>
                   <li>
                     Antes de criar um PR, teste a formatação e erros no seu programa usando o <a href="https://lint.osprogramadores.com">Online Linter</a>.

--- a/layouts/_default/desafios.html
+++ b/layouts/_default/desafios.html
@@ -22,8 +22,8 @@
                     no <a href="https://github.com/osprogramadores/op-desafios/#readme">repositório op-desafios</a>.
                   </li>
                   <li>
-                    Antes de criar um PR, teste a formatação e erros no seu programa usando o <a href="https://lint.osprogramadores.com">Online Linter</a>.
-                    Ignore este passo se a sua linguagem ainda não for suportada pelo Linter.
+                    Antes de criar um pull request (PR), teste a formatação e verifique se há erros no seu programa usando o <a href="https://lint.osprogramadores.com">Online Linter</a>.
+                    Ignore este passo se a sua linguagem for C# ou PHP, ainda não suportadas pelo Linter.
                   </li>
                 </ul>
                 <br>


### PR DESCRIPTION
# Contexto:

@mpinheir me pediu para opinar com alguns comentários sobre a página dos desafios. Iniciei a revisão pelas instruções que aparecem no site Os Programadores (https://osprogramadores.com/desafios/). O texto em si está claro (para mim) mas pode trazer alguma dificuldade para novatos, menos experientes com os termos técnicos.

Além disso, algumas informações extras podem ajudar a nortear, como por exemplo indicar as linguagens não suportadas pelo linter online.

Talvez seja interessante colocar um link para o repositório do linter online para incentivar contribuições, @mpinheir. Talvez até já exista mas eu ainda não vi.

# Commits:

1. **23b08e3** Remoção de um dos links na primeira instrução para os desafios
    - Motivação: Os links levam ambos para o repositório dos desafios, com uma sutil diferença de um link para o README. IMHO, um link basta e potencialmente cause menos confusão.


1. **efedb60** Sugestão de modificar `contribuição` para `solução para um dos desafios` na página de instruções
    - Motivação: Contribuição sugere que algo está sendo acrescentado ao projeto que vai adicionar uma funcionalidade ou corrigir um bug. O contexto da página é restrito aos desafios - assim solução parece ser mais aderente.


1. **d541df1** Inserção de uma expressão completa do que é PR na primeira menção na página dos desafios...
 e listagem das linguagens não suportadas pelo Linter (C# e PHP) para já adiantar o planejamento de quem lê as informações

