### PR TITLE
Remoção de ambiguidade na descrição do desafio 10 - Turing Machine

### DIFF
--- a/content/desafios/d10.md
+++ b/content/desafios/d10.md
@@ -117,11 +117,15 @@ Ex:
 
 ## Descrição
 
-Escreva um programa que leia dois arquivos: O primeiro contendo um "conjunto de
-regras" (o "programa") e o segundo contendo o nome do arquivo de regras a ser
-usado e os dados. O programa deverá executar as regras usando os dados como
+Escreva um programa que leia um arquivo de dados onde cada linha contém duas informações separadas 
+por vírgula: a primeira indica o conjunto de regras a ser seguido (o "programa", extensão `.tur`) e 
+a segunda informação são os dados a serem processados usando o conjunto de regras. O programa 
+deverá executar as regras usando os dados como
 entrada e emitir a saída no formato definido abaixo. Observe que o arquivo de
 dados contém o nome do arquivo de regras a ser usado para cada linha.
+
+Assuma que os arquivos de regras (extensão `.tur`) estão localizados no mesmo diretório do arquivo
+de dados fornecido.
 
 As próximas seções definem os formatos de entrada e saída em maiores detalhes.
 
@@ -129,7 +133,7 @@ As próximas seções definem os formatos de entrada e saída em maiores detalhe
 
 O arquivo de dados contem apenas dois campos por linha, separados por uma
 vírgula. O primeiro campo especifica o nome do arquivo de regras a ser usado
-para os dados nessa linha, e o segundo especifica o dado em si.
+para os dados nessa linha (extensão `.tur`), e o segundo especifica o dado em si.
 
 Exemplo:
 
@@ -143,9 +147,9 @@ No caso acima, o valor "101" deverá ser executado com as regras no arquivo
 `prime.tur` e os resultados impressos. Em seguida, execute `prime.tur` usando o
 valor 102, e finalmente, execute `pali.tur` usando o valor "1001001".
 
-### Arquivo de regras.
+### Arquivo de regras
 
-O arquivo de regras define as regras a serem aplicadas, com uma regra por linha.
+O arquivo de regras (extensão `.tur`) define as regras a serem aplicadas, com uma regra por linha.
 Cada linha é composta por 5 campos, separados por um espaço, no seguinte formato:
 
 ```


### PR DESCRIPTION
A descrição da forma de receber e processar as entradas de dados e arquivos de regras no desafio 10 - Turing machine - está ambígua: Não se processa 2 arquivos imediatamente e sim um único arquivo de dados que indica qual arquivo de regras usar a cada linha processada.

Além disso, não fica explícito como armazenar os arquivos de regras e de dados (visto que nos exemplos mostrados só aparece um nome simples, sem indicação de caminho): adicionei uma menção explícita de que os arquivos de regras estão no mesmo diretório do arquivo de dados. Assim, é possível mover o arquivo de dados para qualquer diretório e, junto com ele, as regras sem afetar o comportamento geral da máquina de Turing no contexto do desafio 10.