### PR TITLE
Corrige problema de exibição

### DIFF
--- a/content/blog/conceitos-essenciais-para-começar.md
+++ b/content/blog/conceitos-essenciais-para-começar.md
@@ -5,7 +5,6 @@ tags = ["programação", "desafios", "github", "programação", "tutorial"]
 categories = ["artigos", "desafios"]
 banner = "img/banners/Le_Penseur_in_the_Jardin_du_Musée_Rodin,_Paris_14_June_2015.jpg"
 +++
-# Introdução
 
 Por vezes, algumas pessoas acabam encontrando dificuldades para iniciar na programação e encontram-se um pouco perdidas em meio à quantidade de recursos e opções disponíveis.
 Aqui nos programadores, buscamos ajudar a todos da melhor forma possível. 


### PR DESCRIPTION
Pequeno ajuste pois o sumário do artigo, na página principal do site, estava exbindo a palavra introdução. Não sei se é um bug do Hugo ou o que é mas removendo o # Introdução, resolve o problema.