### PR TITLE
Sugestão de melhorias no texto do desafio 11 - Primos em Pi

### DIFF
--- a/content/desafios/d11.md
+++ b/content/desafios/d11.md
@@ -78,10 +78,10 @@ Imprima uma linha contendo a maior sequência encontrada, sem espaços. Exemplo:
       pi-1000.txt com as primeiras 1000 casas decimais de π, use:
 
     ```
-    $ cut -c1-1001 <pi-1M.txt >pi-1000.txt
+    $ cut -c1-1002 <pi-1M.txt >pi-1000.txt
     ```
 
-    * Onde `1001` representa o número de decimais desejadas + 1.
+    * Onde `1002` representa o número de decimais desejadas + 2 (o inteiro `3` e o ponto decimal).
 
 1. Quanto estiver razoavelmente satisfeito com os resultados, visite a [página de validação de desafios](https://osprogramadores.com/v). Escolha o número do desafio, digite o seu usuário no Github e cole a sua solução.
 

--- a/content/desafios/d11.md
+++ b/content/desafios/d11.md
@@ -73,7 +73,7 @@ Imprima uma linha contendo a maior sequência encontrada, sem espaços. Exemplo:
 
 1. Rode o seu programa usando o arquivo de dados como entrada (pi-1M.txt)
 
-    * **Dica**: (Linux) Use o comando "cut" para produzir arquivos menores e
+    * **Dica**: (Linux ou no Git Bash, se estiver usando Windows) Use o comando "cut" para produzir arquivos menores e
       testar o seu programa. Por exemplo, para produzir um arquivo chamado
       pi-1000.txt com as primeiras 1000 casas decimais de π, use:
 


### PR DESCRIPTION
- Inclusão de referência ao Git Bash (o comando cut está disponível através dele no Windows)
- Correção do comando `cut` (é necessário um offset de 2 caracteres para descontar o `3` e o ponto decimal)