### PR TITLE
adiciona nota ao parâmetro ```--recursive``` ao clonar um repositório

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Este repositório contém o fonte do website, que usa o [Hugo](http://gohugo.io)
     ```
     git clone --recursive https://github.com/<seu_usuário_no_github>/op-website-hugo.git
     ```
+    >  **Nota:**
+    >  ```--recursive``` é um parâmetro usado para [clonar submódulos](https://git-scm.com/book/en/v2/Git-Tools-Submodules) de um repositório, sendo um pseudônimo do parâmetro ```--recurse-submodules```. A opção é ignorada pelo git se no projeto em questão não houver submódulos. Ou seja, se não houver por exemplo diretórios de projetos de terceiros no repositório.
+
 1. Crie um "remote" apontando para o repositório oficial (upstream):
     ```
     git remote add upstream https://github.com/OsProgramadores/op-website-hugo.git


### PR DESCRIPTION
Este commit adiciona uma nota sobre a utilização do parâmetro ```--recursive``` e o seu pseudômino (alias) no README.md do repositório. 

Eu adicionei um link para a documentação, infelizmente não há tradução para o português desta página. A outra página sobre submódulos que foi traduzida é sobre o comando ```git submodules```, e ela não possui explicação sobre os submódulos em si como nesta página referenciada da documentação. 

Se acharem melhor, vocês podem remover ou substituir o link por um conteúdo em português. Aceito sugestões. 