### PR TITLE
Adicionar descrição para desafio 6.

### DIFF
--- a/content/desafios/d06.md
+++ b/content/desafios/d06.md
@@ -83,6 +83,7 @@ EGO TINE
 * Esse problema é um caso clássico para um algoritmo recursivo.
 * Tentativas usando força bruta não vão funcionar.
 * Esse desafio pode ser considerado como um desafio **médio/difícil**. Discuta dúvidas com os administradores e outros participantes no grupo [OsProgramadores](https://t.me/OsProgramadores) do Telegram.
+* Ao enviar o PR com a solução do desafio, **não** inclua o arquivo com as palavras válidas presente na descrição deste desafio, adicione apenas os arquivos da tua solução.
 
 ## Pontuação
 


### PR DESCRIPTION
Apenas adicionei a descrição no desafio para os participantes enviarem apenas os arquivos com a solução no D6, acho desnecessário enviar o arquivo com as palavras juntos(os PR`s ficam com várias linhas a mais).