### PR TITLE
Adicionar link para linter na seção de validações 

### DIFF
--- a/layouts/_default/desafio.html
+++ b/layouts/_default/desafio.html
@@ -39,6 +39,7 @@
 
                         <ul>
                           <li>Teste o seu programa localmente e verifique que está operando de forma desejada.</li>
+                          <li>Verifique se o teu código está formatado corretamente através do <a href="https://lint.osprogramadores.com/t/form.html">nosso linter</a></li>
                           <li>Se o desafio necessitar de validação (desafio-08 em diante), siga os
                             procedimentos de <a href="#validação">validação</a> descritos acima.</li>
                           <li>Crie um <i>Pull Request</i> (PR) seguindo as <a href="https://github.com/OsProgramadores/op-desafios/blob/master/README.md">


### PR DESCRIPTION
Apenas adicionei um comentário para a galera checar o código no linter antes de enviar, muitos arquivos estão parando na actions devido a erros de formatação.