### PR TITLE
Update .gitignore to ignore Gemini and PLAN files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ Untitled.ipynb
 .vs
 .idea
 .hugo_build.lock
+#ignore Gemini CLI-related files
+GEMINI.md
+PLAN.md


### PR DESCRIPTION
This PR updates the .gitignore file to include GEMINI.md and PLAN.md, which are used for local project management.