### PR TITLE
Add podcast episode 149 with Daniel Jesus

### DIFF
--- a/content/podcast/podcast-149.md
+++ b/content/podcast/podcast-149.md
@@ -1,0 +1,45 @@
++++
+date = "2026-04-27T00:00:00-00:00"
+title = "E149 - Daniel Jesus"
+categories = ["Podcast"]
+tags = ["podcast","osprogramadores"]
+banner = "img/banners/podcast-400px.png"
++++
+
+### Daniel Jesus - Tech Lead @ Banco Daycoval & Microsoft MVP
+
+> Você pode assistir ao episódio [através deste link](https://www.youtube.com/watch?v=n8DEIKmamu0).
+
+{{< spotify type="episode" id="7dJfAq374Eqc73brxDBIq3" width="80%">}}
+
+{{< youtube n8DEIKmamu0 >}}
+
+---
+
+Neste episódio do podcast OsProgramadores, Marcelo conversa com Daniel Jesus, Tech Lead no Banco Daycoval e Microsoft MVP.
+Com mais de 15 anos de experiência em engenharia de software e liderança técnica, Daniel compartilha sua visão sobre como alinhar estratégia de negócio com execução técnica e liderar equipes de alta performance.
+
+Ao longo da conversa, Daniel aborda:
+- Sua trajetória desde o início na programação até se tornar Tech Lead.
+- Experiência técnica com .NET e bancos NoSQL como RavenDB e MongoDB.
+- Modernização de aplicações legadas e integração de sistemas.
+- A importância da comunicação clara entre áreas técnicas e de negócio.
+- Atuação na comunidade e seu reconhecimento como Microsoft MVP.
+
+#### Links mencionados:
+
+- [LinkedIn do Daniel Jesus](https://www.linkedin.com/in/djesusnet/)
+
+---
+
+> Junte-se a nós no [Grupo no Telegram](https://t.me/osprogramadores) para trocar ideias e acompanhar as novidades da nossa comunidade!
+
+**Editor do Episódio**
+
+- Marcelo Pinheiro
+
+**Os Programadores**
+
+- [Grupo no Telegram](https://t.me/osprogramadores)
+- [Canal do Youtube do OsProgramadores](https://www.youtube.com/channel/UCt_YNYGl6K5yNXlXEQDdwWg?view_as=subscriber)
+- [Twitter do Marcelo Pinheiro](https://twitter.com/mpinheir)


### PR DESCRIPTION
This PR adds episode 149 of the OsProgramadores podcast featuring Daniel Jesus, Tech Lead at Banco Daycoval and Microsoft MVP.

The episode includes:
- YouTube link
- Spotify embed
- Episode description and guest information
- Links to Daniel's LinkedIn profile

Co-Authored-By: Oz <oz-agent@warp.dev>