### PR TITLE
Add podcast episode 151: Sandro Mancuso

### DIFF
--- a/content/podcast/podcast-151.md
+++ b/content/podcast/podcast-151.md
@@ -1,0 +1,37 @@
++++
+date = "2026-05-10T00:00:00-00:00"
+title = "E151 - Sandro Mancuso"
+categories = ["Podcast"]
+tags = ["podcast","osprogramadores"]
+banner = "img/banners/podcast-400px.png"
++++
+
+### Sandro Mancuso
+
+> Você pode assistir ao episódio [através deste link](https://youtu.be/8OLVOkeuPYA).
+
+{{< spotify type="episode" id="5Izdmfp9Y5kx5e7NlNFCtJ" width="80%">}}
+
+{{< youtube 8OLVOkeuPYA >}}
+
+---
+
+Neste episódio do podcast OsProgramadores, Marcelo conversa com Sandro Mancuso.
+
+#### Links mencionados:
+
+- [LinkedIn do Sandro Mancuso](https://www.linkedin.com/in/sandromancuso/)
+
+---
+
+> Junte-se a nós no [Grupo no Telegram](https://t.me/osprogramadores) para trocar ideias e acompanhar as novidades da nossa comunidade!
+
+**Editor do Episódio**
+
+- Marcelo Pinheiro
+
+**Os Programadores**
+
+- [Grupo no Telegram](https://t.me/osprogramadores)
+- [Canal do Youtube do OsProgramadores](https://www.youtube.com/channel/UCt_YNYGl6K5yNXlXEQDdwWg?view_as=subscriber)
+- [Twitter do Marcelo Pinheiro](https://twitter.com/mpinheir)


### PR DESCRIPTION
Added the new podcast episode page for Sandro Mancuso (E151). Includes YouTube, Spotify, and LinkedIn links.