### PR TITLE
Feat: Add episode 154 in podcasts catalog

### DIFF
--- a/content/podcast/podcast-154.md
+++ b/content/podcast/podcast-154.md
@@ -1,0 +1,39 @@
++++
+date = "2026-05-31T00:00:00-00:00"
+title = "E154 - Rafael Milewski"
+author = "Marcelo Pinheiro"
+categories = ["Podcast"]
+tags = ["podcast","osprogramadores"]
+banner = "img/banners/podcast-400px.png"
++++
+
+### Rafael Milewski
+
+> Você pode assistir ao episódio [através deste link](https://youtu.be/0TtB3E3pBoU).
+
+{{< spotify type="episode" id="3Tkwd8uQdKByT7Iu3oEUxI" width="80%">}}
+
+{{< youtube 0TtB3E3pBoU >}}
+
+---
+
+Neste episódio do podcast OsProgramadores, Marcelo recebe Rafael Milewski, desenvolvedor full-stack e sócio-diretor da Digital Creative Asia, para um bate-papo profundo sobre sua trajetória internacional. Com mais de uma década vivendo e construindo tecnologia no coração de Xangai, Rafael compartilha uma perspectiva única de quem transita entre culturas e mercados, unindo habilidades técnicas de alta performance com uma veia criativa refinada por anos de experiência em design.
+Durante a conversa, ele abre o jogo sobre os bastidores da tecnologia na China, explorando temas técnicos vitais como a adoção de Rust em sistemas embarcados, as nuances da arquitetura de software moderna e como a Inteligência Artificial está redefinindo o fluxo de trabalho de desenvolvedores ao redor do mundo. Além disso, Rafael discute os desafios reais de escalar produtos digitais de alta complexidade em um ecossistema global extremamente competitivo.
+O episódio é uma reflexão sobre carreira e resiliência: desde o início humilde no Brasil até a posição de liderança técnica no mercado asiático. Rafael compartilha aprendizados valiosos sobre a importância de manter uma cultura maker, a busca constante por eficiência operacional e segurança, e como o aprendizado contínuo é o combustível necessário para quem deseja se destacar em um cenário tecnológico que não para de evoluir.
+
+#### Links mencionados:
+
+- [LinkedIn do Rafael Milewski](https://www.linkedin.com/in/rafael-milewski/)
+
+---
+
+> Junte-se a nós no [Grupo no Telegram](https://t.me/osprogramadores) para trocar ideias e acompanhar as novidades da nossa comunidade!
+
+**Editor do Episódio**
+
+- Marcelo Pinheiro
+
+**Os Programadores**
+
+- [Grupo no Telegram](https://t.me/osprogramadores)
+- [Canal do Youtube do OsProgramadores](https://www.youtube.com/@OsProgramadores)


### PR DESCRIPTION
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/08b00e22-8071-47ba-a36d-0540becf712c" />


- Criação do arquivo Markdown do episódio com o respectivo *frontmatter* (título, autor, categorias e tags).
- Inclusão dos shortcodes do Spotify e YouTube para reprodução direta.
- Adição do resumo descritivo do episódio abordando a trajetória do convidado em Xangai, uso de Rust em sistemas embarcados e Inteligência Artificial.
- Inclusão dos links citados durante o programa (LinkedIn do convidado e site gaGO.io).